### PR TITLE
Rename PHP namespace to Torounit\WP\Schedule_Terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build
 
 /vendor/
 *.tsbuildinfo
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Yes, scheduling can be enabled for any taxonomy that is shown in the admin UI (`
 ### Unreleased
 * Tested WordPress 7.0.
 * Drop support for PHP 8.1.
+* Renamed the internal PHP namespace from `HAMWORKS\WP\Schedule_Terms` to `Torounit\WP\Schedule_Terms` (old class names are aliased for backward compatibility and will be removed in a future major release).
 
 ### 1.3.0
 * Tested WordPress 6.5.

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,12 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"HAMWORKS\\WP\\Schedule_Terms\\": "./includes",
-			"HAMWORKS\\WP\\Schedule_Terms\\Tests\\": "./tests/php"
-		}
+			"Torounit\\WP\\Schedule_Terms\\": "./includes",
+			"Torounit\\WP\\Schedule_Terms\\Tests\\": "./tests/php"
+		},
+		"files": [
+			"includes/compat.php"
+		]
 	},
 	"scripts": {
 		"test": "phpunit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "57fba4be398498a345a461dd3bc160da",
+    "content-hash": "dc78ce983c4e4bfd0b5e3e751834e971",
     "packages": [],
     "packages-dev": [
         {

--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -5,7 +5,7 @@
  * @package Schedule_Terms
  */
 
-namespace HAMWORKS\WP\Schedule_Terms;
+namespace Torounit\WP\Schedule_Terms;
 
 /**
  * Class used to register style and js.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -5,7 +5,7 @@
  * @package Schedule_Terms
  */
 
-namespace HAMWORKS\WP\Schedule_Terms;
+namespace Torounit\WP\Schedule_Terms;
 
 /**
  * Plugin base class.

--- a/includes/Post_Meta.php
+++ b/includes/Post_Meta.php
@@ -5,7 +5,7 @@
  * @package Schedule_Terms
  */
 
-namespace HAMWORKS\WP\Schedule_Terms;
+namespace Torounit\WP\Schedule_Terms;
 
 /**
  * Register post meta.

--- a/includes/Schedule.php
+++ b/includes/Schedule.php
@@ -5,7 +5,7 @@
  * @package Schedule_Terms
  */
 
-namespace HAMWORKS\WP\Schedule_Terms;
+namespace Torounit\WP\Schedule_Terms;
 
 use WP_Term;
 

--- a/includes/Term/UI.php
+++ b/includes/Term/UI.php
@@ -6,7 +6,7 @@
  * @see https://github.com/JJJ/wp-term-meta-ui/blob/master/class-wp-term-meta-ui.php
  */
 
-namespace HAMWORKS\WP\Schedule_Terms\Term;
+namespace Torounit\WP\Schedule_Terms\Term;
 
 use WP_Taxonomy;
 use WP_Term;

--- a/includes/Term_Manager.php
+++ b/includes/Term_Manager.php
@@ -5,7 +5,7 @@
  * @package Schedule_Terms
  */
 
-namespace HAMWORKS\WP\Schedule_Terms;
+namespace Torounit\WP\Schedule_Terms;
 
 use WP_Term;
 

--- a/includes/Term_Meta.php
+++ b/includes/Term_Meta.php
@@ -5,7 +5,7 @@
  * @package Schedule_Terms
  */
 
-namespace HAMWORKS\WP\Schedule_Terms;
+namespace Torounit\WP\Schedule_Terms;
 
 /**
  *  Term Meta class.

--- a/includes/Term_UI.php
+++ b/includes/Term_UI.php
@@ -5,9 +5,9 @@
  * @package Schedule_Terms
  */
 
-namespace HAMWORKS\WP\Schedule_Terms;
+namespace Torounit\WP\Schedule_Terms;
 
-use HAMWORKS\WP\Schedule_Terms\Term\UI;
+use Torounit\WP\Schedule_Terms\Term\UI;
 
 /**
  * Term meta UI controller.

--- a/includes/compat.php
+++ b/includes/compat.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Backward-compatible class aliases for the deprecated
+ * HAMWORKS\WP\Schedule_Terms namespace.
+ *
+ * TODO: remove this file and the "files" autoload entry in a future
+ * major release once the old namespace is no longer supported.
+ *
+ * @package Schedule_Terms
+ */
+
+( function () {
+	$map = array(
+		'HAMWORKS\\WP\\Schedule_Terms\\Assets'       => 'Torounit\\WP\\Schedule_Terms\\Assets',
+		'HAMWORKS\\WP\\Schedule_Terms\\Plugin'       => 'Torounit\\WP\\Schedule_Terms\\Plugin',
+		'HAMWORKS\\WP\\Schedule_Terms\\Post_Meta'    => 'Torounit\\WP\\Schedule_Terms\\Post_Meta',
+		'HAMWORKS\\WP\\Schedule_Terms\\Schedule'     => 'Torounit\\WP\\Schedule_Terms\\Schedule',
+		'HAMWORKS\\WP\\Schedule_Terms\\Term_Manager' => 'Torounit\\WP\\Schedule_Terms\\Term_Manager',
+		'HAMWORKS\\WP\\Schedule_Terms\\Term_Meta'    => 'Torounit\\WP\\Schedule_Terms\\Term_Meta',
+		'HAMWORKS\\WP\\Schedule_Terms\\Term_UI'      => 'Torounit\\WP\\Schedule_Terms\\Term_UI',
+		'HAMWORKS\\WP\\Schedule_Terms\\Term\\UI'     => 'Torounit\\WP\\Schedule_Terms\\Term\\UI',
+	);
+
+	foreach ( $map as $old_class => $new_class ) {
+		if ( ! class_exists( $old_class ) && class_exists( $new_class ) ) {
+			class_alias( $new_class, $old_class );
+		}
+	}
+} )();

--- a/schedule-terms.php
+++ b/schedule-terms.php
@@ -14,7 +14,7 @@
  * @package Schedule_Terms
  */
 
-use HAMWORKS\WP\Schedule_Terms\Plugin;
+use Torounit\WP\Schedule_Terms\Plugin;
 
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/tests/php/Schedule_Test.php
+++ b/tests/php/Schedule_Test.php
@@ -5,9 +5,9 @@
  * @package Schedule_Terms
  */
 
-namespace HAMWORKS\WP\Schedule_Terms\Tests;
+namespace Torounit\WP\Schedule_Terms\Tests;
 
-use HAMWORKS\WP\Schedule_Terms\Schedule;
+use Torounit\WP\Schedule_Terms\Schedule;
 use WP_UnitTestCase;
 
 /**

--- a/tests/php/Term_Manager_Test.php
+++ b/tests/php/Term_Manager_Test.php
@@ -5,9 +5,9 @@
  * @package Schedule_Terms
  */
 
-namespace HAMWORKS\WP\Schedule_Terms\Tests;
+namespace Torounit\WP\Schedule_Terms\Tests;
 
-use HAMWORKS\WP\Schedule_Terms\Term_Manager;
+use Torounit\WP\Schedule_Terms\Term_Manager;
 use WP_UnitTestCase;
 
 /**


### PR DESCRIPTION
## Summary

- Rename the PHP namespace from `HAMWORKS\WP\Schedule_Terms` to `Torounit\WP\Schedule_Terms` to align with the `torounit/schedule-terms` composer package and GitHub ownership.
- Update the PSR-4 mapping in `composer.json` accordingly.
- Add `includes/compat.php` (loaded via composer's `files` autoload) that registers `class_alias()` shims for every old `HAMWORKS\WP\Schedule_Terms\*` class name, so any third-party code still referencing the old FQCNs keeps working (`new`, `instanceof`, type hints, `class_exists()`).
- Note the rename in the README's Unreleased changelog entry.

### Compatibility notes

This plugin is self-contained (bootstraps itself via `new Plugin()`) and isn't consumed as a library, and none of these objects are ever serialized into the database (post/term meta only store scalars/arrays), so the rename carries minimal risk. The `class_alias()` shim covers the realistic compatibility cases (`new`, `instanceof`, type hints, `class_exists()`). Two edge cases it can't fully cover are out of scope given the above: code that references the old FQCN at file top-level before this plugin's autoloader has run, and `get_class()`-based string-equality checks against the old name (since `get_class()` always returns the canonical name). The shim is intended to be removed in a future major release.

## Test plan

- [x] `composer dump-autoload` / `composer update --lock` run cleanly
- [x] `composer lint` passes
- [x] `npm run test:php` (PHPUnit via wp-env) passes
- [x] Verified via `wp eval` on a running wp-env site that both `class_exists('HAMWORKS\WP\Schedule_Terms\Plugin')` and `class_exists('Torounit\WP\Schedule_Terms\Plugin')` return `true`, and the plugin activates without fatal errors