### PR TITLE
Add Requires header fields and fix implicit-nullable deprecations

### DIFF
--- a/includes/Term/UI.php
+++ b/includes/Term/UI.php
@@ -225,13 +225,13 @@ abstract class UI {
 	/**
 	 * Output the value for the custom column
 	 *
-	 * @param string $column_value Custom column output. Default empty.
-	 * @param string $custom_column Name of the column.
-	 * @param int    $term_id Term ID.
+	 * @param string|null $column_value Custom column output. Default empty.
+	 * @param string|null $custom_column Name of the column.
+	 * @param int         $term_id Term ID.
 	 *
 	 * @return string|void
 	 */
-	public function add_column_value( string $column_value = null, string $custom_column = null, int $term_id = 0 ) {
+	public function add_column_value( ?string $column_value = null, ?string $custom_column = null, int $term_id = 0 ) {
 		if ( ! filter_input( INPUT_GET, 'taxonomy' ) && ! filter_input( INPUT_POST, 'taxonomy' ) ) {
 			return $column_value ?? '';
 		}

--- a/includes/Term_Manager.php
+++ b/includes/Term_Manager.php
@@ -45,7 +45,7 @@ class Term_Manager {
 	 * @param string   $term_meta_key Term meta key.
 	 * @param int|null $time timestamp.
 	 */
-	public function __construct( string $post_meta_key, string $term_meta_key, int $time = null ) {
+	public function __construct( string $post_meta_key, string $term_meta_key, ?int $time = null ) {
 		$this->post_meta_key = $post_meta_key;
 		$this->term_meta_key = $term_meta_key;
 		$this->time          = $time ?? time();

--- a/schedule-terms.php
+++ b/schedule-terms.php
@@ -10,6 +10,8 @@
  * Text Domain:     schedule-terms
  * Domain Path:     /languages
  * Version: 1.3.2
+ * Requires at least: 6.7
+ * Requires PHP:      8.2
  *
  * @package Schedule_Terms
  */


### PR DESCRIPTION
## Summary

- Add `Requires at least: 6.7` / `Requires PHP: 8.2` to the plugin header in `schedule-terms.php`, matching what's already documented in README.md.
- Explicitly mark `Term_Manager::__construct()`'s `$time` parameter and `Term\UI::add_column_value()`'s `$column_value` / `$custom_column` parameters as nullable (`?int` / `?string`), resolving the PHP 8.4+ "implicitly marking parameter as nullable is deprecated" warnings surfaced by `composer lint`.

## Test plan

- [x] `composer lint` no longer prints any `Deprecated:` output
- [x] `npm run test:php` (PHPUnit via wp-env) passes