### PR TITLE
Replace experimental @wordpress/components APIs with @wordpress/ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build
 /vendor/
 *.tsbuildinfo
 .phpunit.result.cache
+.playwright-mcp/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@hamworks/schedule-terms",
+	"name": "@torounit/schedule-terms",
 	"version": "1.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@hamworks/schedule-terms",
+			"name": "@torounit/schedule-terms",
 			"version": "1.3.2",
 			"license": "GPL-2.0+",
 			"dependencies": {
@@ -18,6 +18,7 @@
 				"@wordpress/i18n": "^6.21.1",
 				"@wordpress/icons": "^14.0.1",
 				"@wordpress/plugins": "^7.48.1",
+				"@wordpress/ui": "^0.15.1",
 				"moment": "^2.30.1",
 				"wp-types": "^4.70.1"
 			},

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"@wordpress/i18n": "^6.21.1",
 		"@wordpress/icons": "^14.0.1",
 		"@wordpress/plugins": "^7.48.1",
+		"@wordpress/ui": "^0.15.1",
 		"moment": "^2.30.1",
 		"wp-types": "^4.70.1"
 	}

--- a/src/editor/components/DatetimeControl.tsx
+++ b/src/editor/components/DatetimeControl.tsx
@@ -3,17 +3,13 @@ import { useEntityProp } from '@wordpress/core-data';
 import { useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { closeSmall } from '@wordpress/icons';
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
 import {
 	Button,
 	DateTimePicker,
 	Dropdown,
 	PanelRow,
-	__experimentalHStack as HStack,
-	__experimentalHeading as Heading,
-	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
-/* eslint-enable @wordpress/no-unsafe-wp-apis */
+import { Stack, Text } from '@wordpress/ui';
 import { dateI18n, getSettings } from '@wordpress/date';
 // @ts-ignore
 import moment from 'moment';
@@ -164,19 +160,21 @@ export const DatetimeControl = ( {
 				renderContent={ ( { onClose } ) => (
 					<div style={ { padding: 8 } }>
 						<div style={ { marginBottom: '1em' } }>
-							<HStack>
-								{ /* @ts-ignore */ }
-								<Heading level={ 2 } size={ 13 }>
+							<Stack
+								direction="row"
+								justify="space-between"
+								align="center"
+							>
+								<Text variant="heading-sm" render={ <h2 /> }>
 									{ label }
-								</Heading>
-								<Spacer />
+								</Text>
 								<Button
 									className="block-editor-inspector-popover-header__action"
 									label={ __( 'Close' ) }
 									icon={ closeSmall }
 									onClick={ onClose }
 								/>
-							</HStack>
+							</Stack>
 						</div>
 
 						<DateTimePicker


### PR DESCRIPTION
## Summary

- Replace `__experimentalHStack` / `__experimentalHeading` / `__experimentalSpacer` (from `@wordpress/components`) with `@wordpress/ui`'s `Stack` and `Text` in the "Schedule Terms" popover header (`src/editor/components/DatetimeControl.tsx`).
- `Stack`'s `justify="space-between"` replaces the `HStack` + `Spacer` combo (no direct `Spacer` equivalent exists in `@wordpress/ui`).
- `Text` is rendered as an `<h2>` via its `render` prop to preserve the original heading semantics.
- Removes the `eslint-disable @wordpress/no-unsafe-wp-apis` block that was previously needed for this file.
- Adds `@wordpress/ui` (`^0.15.1`) as a dependency. No extra theme/CSS setup is needed since this component renders inside the block editor, where `@wordpress/ui`'s docs say styling is handled by the surrounding Gutenberg context.

Note: `@wordpress/ui` is still a 0.x package and its own README says it's "still experimental" (i.e. its API may have breaking changes across minor versions), even though it doesn't use the `__experimental` naming convention that the lint rule checks for.

## Test plan

- [x] `npm run lint:type` passes
- [x] `npm run lint-js` passes (no more `@wordpress/no-unsafe-wp-apis` warnings)
- [x] `npm run build` succeeds
- [x] Verified visually in wp-env: opened the "Schedule Terms" panel's Attach/Detach dropdown on a post and confirmed the title and close button are laid out the same as before (title left, close button pushed to the right)