### PR TITLE
Add release-it for tagging and GitHub releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "@hamworks/schedule-terms",
+	"name": "@torounit/schedule-terms",
 	"version": "1.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "@hamworks/schedule-terms",
+			"name": "@torounit/schedule-terms",
 			"version": "1.3.2",
 			"license": "GPL-2.0+",
 			"dependencies": {
@@ -26,6 +26,7 @@
 				"@wordpress/scripts": "^32.4.1",
 				"husky": "^9.1.7",
 				"lint-staged": "^17.0.7",
+				"release-it": "^20.2.0",
 				"typescript": "^5.4.2"
 			}
 		},
@@ -4996,6 +4997,201 @@
 				"@octokit/openapi-types": "^24.2.0"
 			}
 		},
+		"node_modules/@octokit/rest": {
+			"version": "22.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+			"integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/core": "^7.0.6",
+				"@octokit/plugin-paginate-rest": "^14.0.0",
+				"@octokit/plugin-request-log": "^6.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+			"integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/core": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-token": "^6.0.0",
+				"@octokit/graphql": "^9.0.3",
+				"@octokit/request": "^10.0.6",
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
+				"before-after-hook": "^4.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+			"integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^16.0.0",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/graphql": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+			"integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^10.0.6",
+				"@octokit/types": "^16.0.0",
+				"universal-user-agent": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+			"integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^16.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/plugin-request-log": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+			"integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+			"integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^16.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=6"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/request": {
+			"version": "10.0.10",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+			"integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^11.0.3",
+				"@octokit/request-error": "^7.0.2",
+				"@octokit/types": "^16.0.0",
+				"content-type": "^2.0.0",
+				"json-with-bigint": "^3.5.3",
+				"universal-user-agent": "^7.0.2"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/request-error": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+			"integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^16.0.0"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/@octokit/types": {
+			"version": "16.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^27.0.0"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/before-after-hook": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+			"integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@octokit/rest/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/@octokit/rest/node_modules/universal-user-agent": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/@octokit/types": {
 			"version": "12.6.0",
 			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
@@ -6270,6 +6466,20 @@
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@phun-ky/typeof": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@phun-ky/typeof/-/typeof-2.0.3.tgz",
+			"integrity": "sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.9.0 || >=22.0.0",
+				"npm": ">=10.8.2"
+			},
+			"funding": {
+				"url": "https://github.com/phun-ky/typeof?sponsor=1"
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -7800,6 +8010,13 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
 			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+		},
+		"node_modules/@types/parse-path": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
+			"integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/pg": {
 			"version": "8.6.1",
@@ -13307,6 +13524,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/async-retry": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+			"integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"retry": "0.13.1"
+			}
+		},
 		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -14115,6 +14342,22 @@
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/bytes": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -14122,6 +14365,65 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/c12": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
+			"integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chokidar": "^5.0.0",
+				"confbox": "^0.2.2",
+				"defu": "^6.1.4",
+				"dotenv": "^17.2.3",
+				"exsolve": "^1.0.8",
+				"giget": "^2.0.0",
+				"jiti": "^2.6.1",
+				"ohash": "^2.0.11",
+				"pathe": "^2.0.3",
+				"perfect-debounce": "^2.0.0",
+				"pkg-types": "^2.3.0",
+				"rc9": "^2.1.2"
+			},
+			"peerDependencies": {
+				"magicast": "*"
+			},
+			"peerDependenciesMeta": {
+				"magicast": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/c12/node_modules/chokidar": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+			"integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readdirp": "^5.0.0"
+			},
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/c12/node_modules/readdirp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+			"integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 20.19.0"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://paulmillr.com/funding/"
 			}
 		},
 		"node_modules/cacheable": {
@@ -14524,6 +14826,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/citty": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+			"integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"consola": "^3.2.3"
+			}
+		},
 		"node_modules/cjs-module-lexer": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -14920,6 +15232,13 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
+		"node_modules/confbox": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+			"integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/configstore": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
@@ -14946,6 +15265,16 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8"
+			}
+		},
+		"node_modules/consola": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+			"integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.18.0 || >=16.10.0"
 			}
 		},
 		"node_modules/constant-case": {
@@ -15798,6 +16127,36 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/default-browser": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+			"integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/default-gateway": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -15876,6 +16235,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/defu": {
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+			"integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/degenerator": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
@@ -15926,6 +16292,13 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/destr": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+			"integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
@@ -16145,6 +16518,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dunder-proto": {
@@ -17280,6 +17666,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/eta": {
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/eta/-/eta-4.5.1.tgz",
+			"integrity": "sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/bgub/eta?sponsor=1"
+			}
+		},
 		"node_modules/etag": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -17475,6 +17874,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/exsolve": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
+			"integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/extract-zip": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -17557,6 +17963,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-string-width": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^3.0.2"
+			}
+		},
 		"node_modules/fast-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -17573,6 +17996,16 @@
 				}
 			],
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^3.0.2"
+			}
 		},
 		"node_modules/fast-xml-builder": {
 			"version": "1.2.0",
@@ -18445,6 +18878,45 @@
 			"dependencies": {
 				"encoding": "^0.1.12",
 				"safe-buffer": "^5.1.1"
+			}
+		},
+		"node_modules/giget": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+			"integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"citty": "^0.1.6",
+				"consola": "^3.4.0",
+				"defu": "^6.1.4",
+				"node-fetch-native": "^1.6.6",
+				"nypm": "^0.6.0",
+				"pathe": "^2.0.3"
+			},
+			"bin": {
+				"giget": "dist/cli.mjs"
+			}
+		},
+		"node_modules/git-up": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
+			"integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-ssh": "^1.4.0",
+				"parse-url": "^9.2.0"
+			}
+		},
+		"node_modules/git-url-parse": {
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
+			"integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"git-up": "^8.1.0"
 			}
 		},
 		"node_modules/gl-matrix": {
@@ -19670,6 +20142,54 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-in-ssh": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+			"integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-interactive": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -19811,6 +20331,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-ssh": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
+			"integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"protocols": "^2.0.1"
 			}
 		},
 		"node_modules/is-stream": {
@@ -20087,6 +20617,23 @@
 			"funding": {
 				"type": "GitHub Sponsors ❤",
 				"url": "https://github.com/sponsors/dmonad"
+			}
+		},
+		"node_modules/issue-parser": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
+			"integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lodash.capitalize": "^4.2.1",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.uniqby": "^4.7.0"
+			},
+			"engines": {
+				"node": "^18.17 || >=20.6.1"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -21025,6 +21572,16 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
 		"node_modules/joi": {
 			"version": "18.2.1",
 			"resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
@@ -21162,6 +21719,13 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-with-bigint": {
+			"version": "3.5.8",
+			"resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+			"integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -21851,10 +22415,24 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lodash.capitalize": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -21911,8 +22489,7 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
@@ -21933,6 +22510,13 @@
 			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
 			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
 			"dev": true
+		},
+		"node_modules/lodash.uniqby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/log-symbols": {
 			"version": "4.1.0",
@@ -22207,6 +22791,19 @@
 			"dev": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/macos-release": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-3.5.1.tgz",
+			"integrity": "sha512-Lci/1in+elqZ589PXnfP/iwZXpwQifTM94WJRQwG2tZSdfY7NfB/aUaTARHrohWCgHlXoabeaeXRDOnF5X9JQw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/make-dir": {
@@ -22995,6 +23592,35 @@
 				"node": ">= 0.4.0"
 			}
 		},
+		"node_modules/new-github-release-url": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/new-github-release-url/-/new-github-release-url-2.0.0.tgz",
+			"integrity": "sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^2.5.1"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/new-github-release-url/node_modules/type-fest": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/no-case": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
@@ -23030,6 +23656,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/node-fetch-native": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+			"integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/node-forge": {
 			"version": "1.3.1",
@@ -23243,6 +23876,31 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/nypm": {
+			"version": "0.6.7",
+			"resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.7.tgz",
+			"integrity": "sha512-s3ds97SD5pd1dULE+tHUk1DrV0cSHOnsfpcdGATJ8JpBo21DoKqN9exTH4/2nhPQNOLomBdTFMicN94S4DrZrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"citty": "^0.2.2",
+				"pathe": "^2.0.3",
+				"tinyexec": "^1.2.4"
+			},
+			"bin": {
+				"nypm": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/nypm/node_modules/citty": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+			"integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -23398,6 +24056,13 @@
 			"engines": {
 				"node": ">= 18"
 			}
+		},
+		"node_modules/ohash": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
@@ -23617,6 +24282,23 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/os-name": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/os-name/-/os-name-7.0.0.tgz",
+			"integrity": "sha512-/HfRU/lPPr4T2VigM+cvM3cU77es+XF4OEAa4aE5zpdvrxHGD2NmH0AFIWpMNAb+CsZL45rlcIO49Re0ZcRseg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"macos-release": "^3.4.0",
+				"windows-release": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/own-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -23806,12 +24488,36 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/parse-path": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+			"integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"protocols": "^2.0.0"
+			}
+		},
 		"node_modules/parse-statements": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
 			"integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/parse-url": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
+			"integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/parse-path": "^7.0.0",
+				"parse-path": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.13.0"
+			}
 		},
 		"node_modules/parse5": {
 			"version": "7.3.0",
@@ -23967,10 +24673,24 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pathe": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/perfect-debounce": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
+			"integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -24108,6 +24828,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/pkg-types": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+			"integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"confbox": "^0.2.4",
+				"exsolve": "^1.0.8",
+				"pathe": "^2.0.3"
 			}
 		},
 		"node_modules/playwright": {
@@ -24928,6 +25660,19 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/powershell-utils": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+			"integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/preact": {
 			"version": "10.29.2",
 			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
@@ -25061,6 +25806,13 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT"
+		},
+		"node_modules/protocols": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+			"integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/proxy-addr": {
@@ -25251,6 +26003,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/quickjs-wasi": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-0.0.1.tgz",
+			"integrity": "sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -25306,6 +26065,17 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/rc9": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+			"integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"defu": "^6.1.4",
+				"destr": "^2.0.3"
 			}
 		},
 		"node_modules/re-resizable": {
@@ -25834,6 +26604,949 @@
 				"regjsparser": "bin/parser"
 			}
 		},
+		"node_modules/release-it": {
+			"version": "20.2.0",
+			"resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.0.tgz",
+			"integrity": "sha512-9ZTk9ripgctC6VTqH+P54KuboK29A5mG/I3tFfS5hnoAnkwtFFAMHRidYz93ylrW995vF50Ny1aOGJiyRmEN7w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/webpro"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/webpro"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/prompts": "8.4.2",
+				"@octokit/rest": "22.0.1",
+				"@phun-ky/typeof": "2.0.3",
+				"async-retry": "1.3.3",
+				"c12": "3.3.3",
+				"ci-info": "^4.4.0",
+				"defu": "^6.1.7",
+				"eta": "4.5.1",
+				"git-url-parse": "16.1.0",
+				"issue-parser": "7.0.1",
+				"lodash.merge": "4.6.2",
+				"mime-types": "3.0.2",
+				"new-github-release-url": "2.0.0",
+				"open": "11.0.0",
+				"ora": "9.3.0",
+				"os-name": "7.0.0",
+				"proxy-agent": "7.0.0",
+				"semver": "7.7.4",
+				"tinyglobby": "0.2.15",
+				"undici": "7.24.5",
+				"url-join": "5.0.0",
+				"wildcard-match": "5.1.4",
+				"yargs-parser": "22.0.0"
+			},
+			"bin": {
+				"release-it": "bin/release-it.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/ansi": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+			"integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/checkbox": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.1.tgz",
+			"integrity": "sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/confirm": {
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.1.1.tgz",
+			"integrity": "sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/core": {
+			"version": "11.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.2.1.tgz",
+			"integrity": "sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7",
+				"cli-width": "^4.1.0",
+				"fast-wrap-ansi": "^0.2.0",
+				"mute-stream": "^3.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/editor": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.2.2.tgz",
+			"integrity": "sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/external-editor": "^3.0.3",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/expand": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.1.tgz",
+			"integrity": "sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/external-editor": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.3.tgz",
+			"integrity": "sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.2"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/figures": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.7.tgz",
+			"integrity": "sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/input": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.2.tgz",
+			"integrity": "sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/number": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.1.1.tgz",
+			"integrity": "sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/password": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.1.tgz",
+			"integrity": "sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/prompts": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
+			"integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^5.1.4",
+				"@inquirer/confirm": "^6.0.12",
+				"@inquirer/editor": "^5.1.1",
+				"@inquirer/expand": "^5.0.13",
+				"@inquirer/input": "^5.0.12",
+				"@inquirer/number": "^4.0.12",
+				"@inquirer/password": "^5.0.12",
+				"@inquirer/rawlist": "^5.2.8",
+				"@inquirer/search": "^4.1.8",
+				"@inquirer/select": "^5.1.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/rawlist": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.1.tgz",
+			"integrity": "sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/search": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.2.1.tgz",
+			"integrity": "sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/select": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.1.tgz",
+			"integrity": "sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^11.2.1",
+				"@inquirer/figures": "^2.0.7",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/@inquirer/type": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+			"integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/agent-base": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
+			"integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/release-it/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/release-it/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/release-it/node_modules/ci-info": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/release-it/node_modules/cli-cursor": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/cli-spinners": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+			"integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/data-uri-to-buffer": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-7.0.0.tgz",
+			"integrity": "sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/release-it/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/degenerator": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-6.0.0.tgz",
+			"integrity": "sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"quickjs-wasi": "^0.0.1"
+			}
+		},
+		"node_modules/release-it/node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/release-it/node_modules/get-uri": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-7.0.0.tgz",
+			"integrity": "sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "7.0.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/release-it/node_modules/http-proxy-agent": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
+			"integrity": "sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "8.0.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/release-it/node_modules/https-proxy-agent": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
+			"integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "8.0.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/release-it/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/release-it/node_modules/is-interactive": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+			"integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/is-unicode-supported": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+			"integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/log-symbols": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+			"integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-unicode-supported": "^2.0.0",
+				"yoctocolors": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/release-it/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/release-it/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/release-it/node_modules/mute-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/release-it/node_modules/onetime": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/open": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+			"integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"default-browser": "^5.4.0",
+				"define-lazy-prop": "^3.0.0",
+				"is-in-ssh": "^1.0.0",
+				"is-inside-container": "^1.0.0",
+				"powershell-utils": "^0.1.0",
+				"wsl-utils": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/ora": {
+			"version": "9.3.0",
+			"resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
+			"integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.6.2",
+				"cli-cursor": "^5.0.0",
+				"cli-spinners": "^3.2.0",
+				"is-interactive": "^2.0.0",
+				"is-unicode-supported": "^2.1.0",
+				"log-symbols": "^7.0.1",
+				"stdin-discarder": "^0.3.1",
+				"string-width": "^8.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/pac-proxy-agent": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz",
+			"integrity": "sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "8.0.0",
+				"debug": "^4.3.4",
+				"get-uri": "7.0.0",
+				"http-proxy-agent": "8.0.0",
+				"https-proxy-agent": "8.0.0",
+				"pac-resolver": "8.0.0",
+				"quickjs-wasi": "^0.0.1",
+				"socks-proxy-agent": "9.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/release-it/node_modules/pac-resolver": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-8.0.0.tgz",
+			"integrity": "sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"degenerator": "6.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			},
+			"peerDependencies": {
+				"quickjs-wasi": "^0.0.1"
+			}
+		},
+		"node_modules/release-it/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/release-it/node_modules/powershell-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+			"integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/proxy-agent": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-7.0.0.tgz",
+			"integrity": "sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "8.0.0",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "8.0.0",
+				"https-proxy-agent": "8.0.0",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "8.0.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "9.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/release-it/node_modules/restore-cursor": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^7.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/release-it/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/release-it/node_modules/socks-proxy-agent": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz",
+			"integrity": "sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "8.0.0",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/release-it/node_modules/string-width": {
+			"version": "8.2.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+			"integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.5.0",
+				"strip-ansi": "^7.1.2"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/release-it/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/release-it/node_modules/tinyglobby": {
+			"version": "0.2.15",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/release-it/node_modules/yargs-parser": {
+			"version": "22.0.0",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=23"
+			}
+		},
 		"node_modules/rememo": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
@@ -26102,6 +27815,19 @@
 			},
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/run-con": {
@@ -27520,6 +29246,19 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/stdin-discarder": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+			"integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/stop-iteration-iterator": {
@@ -29410,6 +31149,16 @@
 				"through": "^2.3.8"
 			}
 		},
+		"node_modules/undici": {
+			"version": "7.24.5",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+			"integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -29591,6 +31340,16 @@
 			"dev": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/url-join": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
 		"node_modules/url-loader": {
@@ -30568,6 +32327,29 @@
 			"integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
 			"dev": true
 		},
+		"node_modules/wildcard-match": {
+			"version": "5.1.4",
+			"resolved": "https://registry.npmjs.org/wildcard-match/-/wildcard-match-5.1.4.tgz",
+			"integrity": "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/windows-release": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/windows-release/-/windows-release-7.1.1.tgz",
+			"integrity": "sha512-0GBwC9WmR8Bm3WYiz3FC391054BsFHZ2gzBVdYj9uj5eIVYzbn/YPYCYW9SWdh9vwnLuzpn1UGwJKiMG4F236w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"powershell-utils": "^0.2.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/word-wrap": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -30668,6 +32450,52 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/wsl-utils": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+			"integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-wsl": "^3.1.0",
+				"powershell-utils": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wsl-utils/node_modules/is-wsl": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wsl-utils/node_modules/powershell-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+			"integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/xdg-basedir": {
@@ -30859,6 +32687,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"lint-js": "wp-scripts lint-js",
 		"lint-js:fix": "wp-scripts lint-js --fix",
 		"lint:type": "tsc",
-		"prepare": "husky install"
+		"prepare": "husky install",
+		"release": "release-it"
 	},
 	"repository": {
 		"type": "git",
@@ -29,6 +30,7 @@
 		"@wordpress/env": "^11.8.1",
 		"husky": "^9.1.7",
 		"lint-staged": "^17.0.7",
+		"release-it": "^20.2.0",
 		"typescript": "^5.4.2"
 	},
 	"lint-staged": {


### PR DESCRIPTION
## Summary

- `package.json` already had a `release-it` config (`before:bump` hook running `bin/bump-version.sh`), but the `release-it` package itself was never installed and there was no script to run it.
- Add `release-it` (`^20.2.0`, matching the version used in `slug-automator`) to devDependencies and add an `npm run release` script.

## Test plan

- [x] `npx release-it patch --dry-run --no-npm.publish --no-git.requireUpstream --ci` runs the full flow end-to-end in dry-run mode: `bin/bump-version.sh` hook, commit, tag, push, and GitHub release URL generation all simulated correctly with no real changes made (verified `git status`/`git tag` afterward).